### PR TITLE
Implement hourly data fetching with node-cron and add test metadata

### DIFF
--- a/server/data/node_Metadata.json
+++ b/server/data/node_Metadata.json
@@ -24,5 +24,18 @@
       "type": null,
       "description": null
     }
+  },
+  {
+    "nodeId": "test-000",
+    "locationName": "test",
+    "latitude": 9.710301,
+    "longitude": 76.681433,
+    "yellow_alert": 1,
+    "orange_alert": 2,
+    "red_alert": 3,
+    "otherMetadata": {
+      "type": null,
+      "description": null
+    }
   }
 ]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "mongoose": "^8.5.2",
+        "node-cron": "^3.0.3",
         "nodemon": "^3.1.4"
       }
     },
@@ -922,6 +923,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
@@ -1371,6 +1383,14 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "mongoose": "^8.5.2",
+    "node-cron": "^3.0.3",
     "nodemon": "^3.1.4"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,6 @@ const cros = require("cors");
 const connectDB = require("./config/databaseConnect");
 const NodeAuthenticate = require("./middleware/NodeAuthenticate");
 require("dotenv").config();
-const fetchAndStoreData = require(".//utils/hourlyfetch_kidangoorData");
 const cron = require("node-cron");
 
 const app = express();
@@ -20,13 +19,14 @@ app.use("/v1/node-data/add",NodeAuthenticate, require("./routes/nodeEndpoint"));
 app.use("/v1/node-metadata", require("./routes/nodeMetadataRoutes")); //? Route to get node metadata
 app.use("/v1/water-level", require("./routes/getWaterlevel")); //? Route to get water level data
 
+//const fetchAndStoreData = require(".//utils/hourlyfetch_kidangoorData");
 // Schedule the hourly task
-cron.schedule("0 * * * *", async () => {
-  console.log(`[${new Date().toISOString()}] Running hourly data fetch cycle...`);
-  await fetchAndStoreData();
-});
-// Run immediately on start
-fetchAndStoreData();
+// cron.schedule("0 * * * *", async () => {
+//   console.log(`[${new Date().toISOString()}] Running hourly data fetch cycle...`);
+//   await fetchAndStoreData();
+// });
+// // Run immediately on start
+// fetchAndStoreData();s
 
 app.listen(port, () =>
     console.log(`Server is running on port  http://localhost:${port}`)

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,8 @@ const cros = require("cors");
 const connectDB = require("./config/databaseConnect");
 const NodeAuthenticate = require("./middleware/NodeAuthenticate");
 require("dotenv").config();
-
+const fetchAndStoreData = require(".//utils/hourlyfetch_kidangoorData");
+const cron = require("node-cron");
 
 const app = express();
 const port = process.env.PORT;
@@ -18,6 +19,14 @@ app.use("/", require("./routes/health")); //? Test route to check if the server 
 app.use("/v1/node-data/add",NodeAuthenticate, require("./routes/nodeEndpoint")); //? Route to receive data from IoT nodes
 app.use("/v1/node-metadata", require("./routes/nodeMetadataRoutes")); //? Route to get node metadata
 app.use("/v1/water-level", require("./routes/getWaterlevel")); //? Route to get water level data
+
+// Schedule the hourly task
+cron.schedule("0 * * * *", async () => {
+  console.log(`[${new Date().toISOString()}] Running hourly data fetch cycle...`);
+  await fetchAndStoreData();
+});
+// Run immediately on start
+fetchAndStoreData();
 
 app.listen(port, () =>
     console.log(`Server is running on port  http://localhost:${port}`)

--- a/server/utils/hourlyfetch_kidangoorData.js
+++ b/server/utils/hourlyfetch_kidangoorData.js
@@ -1,0 +1,71 @@
+const axios = require("axios");
+const IotNodeData = require("../schema/NodeDataSchema");
+
+// Function to get current and previous dates in YYYY-MM-DD format
+const getDates = () => {
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+
+  return {
+    startDate: yesterday.toISOString().split("T")[0], // Format as YYYY-MM-DD
+    endDate: today.toISOString().split("T")[0], // Format as YYYY-MM-DD
+  };
+};
+
+// Function to fetch data and store it in MongoDB
+const fetchAndStoreData = async () => {
+  try {
+    console.log(`[${new Date().toISOString()}] Fetching data from API...`);
+
+    // Prepare request body
+    const { startDate, endDate } = getDates();
+    const requestBody = {
+      stationCode: "015-SWRDKOCHI", // No change
+      startDate,
+      endDate,
+    };
+
+    // Fetch data from the API
+    const response = await axios.post(
+      "https://ffs.india-water.gov.in/web-api/getHGStationAllDetailsForFFS",
+      requestBody
+    );
+
+    console.log(response.data);
+
+    const stations = response.data; // Array of station objects
+    const nodeId = "kidangoor-001";
+
+    for (const station of stations) {
+      if (station.hhs && Array.isArray(station.hhs)) {
+        for (const entry of station.hhs) {
+          const utcTime = new Date(entry.actualTime).toISOString();
+
+          // Check if the record already exists
+          const exists = await IotNodeData.findOne({ nodeId, timestamp: utcTime });
+
+          if (!exists) {
+            // Insert new document if it doesn't exist
+            const newDocument = new IotNodeData({
+              nodeId,
+              waterLevel: entry.value,
+              timestamp: utcTime,
+            });
+
+            await newDocument.save();
+            console.log(`[${new Date().toISOString()}] Added new entry for timestamp: ${utcTime}`);
+          } else {
+            console.log(`[${new Date().toISOString()}] Entry for timestamp ${utcTime} already exists.`);
+          }
+        }
+      } else {
+        console.log(`[${new Date().toISOString()}] No HHS data found for station: ${station.stationCode}`);
+      }
+    }
+  } catch (error) {
+    console.error(`[${new Date().toISOString()}] Error fetching or processing data:`, error.message);
+  }
+};
+
+module.exports = fetchAndStoreData;


### PR DESCRIPTION
Introduce node-cron for scheduling hourly data fetches and implement logic for storing fetched data. Add test node metadata for validation purposes. Comment out the hourly fetch logic in the server for future use.